### PR TITLE
🪲 fix: fix bug where hidden elements are still calculated in `calcula…

### DIFF
--- a/Sources/FrameUI/Utilities/StackLayout.swift
+++ b/Sources/FrameUI/Utilities/StackLayout.swift
@@ -227,6 +227,7 @@ public struct StackLayout {
         for elements: [StackElement],
         direction: StackDirection
     ) -> CGSize {
+        let elements = handleHiddenElements(elements: elements)
         var totalMain: CGFloat = 0
         var maxCross: CGFloat = 0
 


### PR DESCRIPTION
…teFittingSize`